### PR TITLE
Add list view to main Collection Page

### DIFF
--- a/components/Collection/index.tsx
+++ b/components/Collection/index.tsx
@@ -1,31 +1,36 @@
 import Image from 'next/image'
 import Link from 'next/link'
-import { chainConfig } from '~/lib/constants';
-import { useGetAllPools } from '~/queries/useGetAllPools';
+import { chainConfig } from '~/lib/constants'
+import { useGetAllPools } from '~/queries/useGetAllPools'
 
 interface IBorrowCollectionItemProps {
-	data: { name: string; address: string; imgUrl: string, oraclePrice?: string }
+	data: { name: string; address: string; imgUrl: string; oraclePrice?: string }
 	chainName: string
 	chainId?: number
 }
 
 export function BorrowCollectionItemList({ data, chainName, chainId }: IBorrowCollectionItemProps) {
-	const { data: pools} = useGetAllPools({ chainId, collectionAddress: data.address })
+	const { data: pools } = useGetAllPools({ chainId, collectionAddress: data.address })
 	const chainSymbol = chainConfig(chainId)?.nativeCurrency?.symbol
 	const floorPrice = Number(data.oraclePrice) / 1e18
-	const poolsWithLiquidity = pools?.filter(pool => Number(pool.totalDeposited) / 1e18 > 0.01)
-	const poolsTotalAvailableBalance = poolsWithLiquidity && poolsWithLiquidity?.map(pool => Number(pool.poolBalance) / 1e18).reduce((a, b) => a + b, 0)
-	const poolsMaxApr = poolsWithLiquidity && Math.max(...poolsWithLiquidity?.map(pool => Number(pool.currentAnnualInterest) / 1e16))
+	const poolsWithLiquidity = pools?.filter((pool) => Number(pool.totalDeposited) / 1e18 > 0.01)
+	const poolsTotalAvailableBalance =
+		poolsWithLiquidity && poolsWithLiquidity?.map((pool) => Number(pool.poolBalance) / 1e18).reduce((a, b) => a + b, 0)
+	const poolsMaxApr =
+		poolsWithLiquidity &&
+		poolsWithLiquidity.length > 0 &&
+		Math.max(...poolsWithLiquidity.map((pool) => Number(pool.currentAnnualInterest) / 1e16))
+
 	return (
-		<li className="grid grid-cols-3 md:grid-cols-6 gap-4 min-h-[80px] min-w-[300px] bg-[#191919] p-4 shadow backdrop-blur justify-between">
+		<li className="grid min-h-[80px] min-w-[300px] grid-cols-3 justify-between gap-4 bg-[#191919] p-4 shadow backdrop-blur first-of-type:rounded-t-xl last-of-type:rounded-b-xl md:grid-cols-6">
 			<div className="flex gap-4">
 				<div className="flex flex-col justify-center">
-					<div className="relative min-h-[50px] min-w-[50px] w-full aspect-square">
+					<div className="relative aspect-square min-h-[50px] w-full min-w-[50px]">
 						{data.imgUrl === '' ? (
 							<div className="aspect-square rounded-xl bg-[#22242A]"></div>
 						) : (
-							<Image src={data.imgUrl} fill alt={data.name} className="aspect-square rounded-xl"  priority />
-						)}						
+							<Image src={data.imgUrl} fill alt={data.name} className="aspect-square rounded-xl" priority />
+						)}
 					</div>
 				</div>
 
@@ -41,12 +46,12 @@ export function BorrowCollectionItemList({ data, chainName, chainId }: IBorrowCo
 			</div>
 
 			<div className="flex flex-col justify-center">
-				<h1>{data.oraclePrice ? `${floorPrice.toFixed(2)} ${chainSymbol}` : ''}</h1>
+				<h1 className="min-h-[1.4rem]">{data.oraclePrice ? `${floorPrice.toFixed(2)} ${chainSymbol}` : '-'}</h1>
 				<p className="text-sm text-[#D4D4D8]">Floor</p>
 			</div>
 
 			<div className="flex flex-col justify-center">
-				<h1>{poolsMaxApr && `${poolsMaxApr.toFixed(2)}%`}</h1>
+				<h1 className="min-h-[1.4rem]">{poolsMaxApr ? `${poolsMaxApr.toFixed(2)}%` : '-'}</h1>
 				<p className="text-sm text-[#D4D4D8]">APR up to</p>
 			</div>
 
@@ -63,7 +68,7 @@ export function BorrowCollectionItemList({ data, chainName, chainId }: IBorrowCo
 			<div className="flex flex-col justify-center">
 				<Link
 					href={`/collections/${chainName}/${data.address}`}
-					className="rounded-xl bg-[#243b55] p-2 text-center text-sm min-w-[100px] max-w-[120px]"
+					className="ml-auto min-w-[100px] max-w-[120px] rounded-xl bg-[#243b55] p-2 text-center text-sm"
 				>
 					View Pools
 				</Link>

--- a/components/Collection/index.tsx
+++ b/components/Collection/index.tsx
@@ -15,10 +15,11 @@ export function BorrowCollectionItemList({ data, chainName, chainId }: IBorrowCo
 	const { data: pools} = useGetAllPools({ chainId, collectionAddress: data.address })
 	const chainSymbol = chainConfig(chainId)?.nativeCurrency?.symbol
 	const floorPrice = Number(oracle?.price) / 1e18
-	const poolsWithLiquidity = pools?.filter(pool => Number(pool.totalDeposited) > 0)
+	const poolsWithLiquidity = pools?.filter(pool => Number(pool.totalDeposited) / 1e18 > 0.01)
 	const poolsTotalAvailableBalance = poolsWithLiquidity && poolsWithLiquidity?.map(pool => Number(pool.poolBalance) / 1e18).reduce((a, b) => a + b, 0)
+	const poolsMaxApr = poolsWithLiquidity && Math.max(...poolsWithLiquidity?.map(pool => Number(pool.currentAnnualInterest) / 1e16))
 	return (
-		<li className="grid grid-cols-3 md:grid-cols-5 gap-4 min-h-[80px] min-w-[300px] bg-[#191919] p-4 shadow backdrop-blur justify-between">
+		<li className="grid grid-cols-3 md:grid-cols-6 gap-4 min-h-[80px] min-w-[300px] bg-[#191919] p-4 shadow backdrop-blur justify-between">
 			<div className="flex gap-4">
 				<div className="flex flex-col justify-center">
 					<div className="relative min-h-[50px] min-w-[50px] w-full aspect-square">
@@ -44,6 +45,11 @@ export function BorrowCollectionItemList({ data, chainName, chainId }: IBorrowCo
 			<div className="flex flex-col justify-center">
 				<h1>{oracle?.price ? `${floorPrice.toFixed(2)} ${chainSymbol}` : ''}</h1>
 				<p className="text-sm text-[#D4D4D8]">Floor</p>
+			</div>
+
+			<div className="flex flex-col justify-center">
+				<h1>{poolsMaxApr && `${poolsMaxApr.toFixed(2)}%`}</h1>
+				<p className="text-sm text-[#D4D4D8]">APR up to</p>
 			</div>
 
 			<div className="flex flex-col justify-center">

--- a/components/Collection/index.tsx
+++ b/components/Collection/index.tsx
@@ -58,7 +58,7 @@ export function BorrowCollectionItemList({ data, chainName }: IBorrowCollectionI
 	)
 }
 
-export function BorrowCollectionItem({ data, chainName }: IBorrowCollectionItemProps) {
+export function BorrowCollectionItemCard({ data, chainName }: IBorrowCollectionItemProps) {
 	return (
 		<li className="flex min-h-[300px] min-w-[240px] flex-col gap-4 rounded-xl bg-[#191919] p-4 shadow backdrop-blur">
 			<div className="relative -mx-4 -mt-4 aspect-square rounded-t-xl bg-[#22242A]">

--- a/components/Collection/index.tsx
+++ b/components/Collection/index.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import { chainConfig } from '~/lib/constants';
+import { useGetAllPools } from '~/queries/useGetAllPools';
 import { useGetOracle } from '~/queries/useGetOracle';
 
 interface IBorrowCollectionItemProps {
@@ -11,6 +12,7 @@ interface IBorrowCollectionItemProps {
 
 export function BorrowCollectionItemList({ data, chainName, chainId }: IBorrowCollectionItemProps) {
 	const { data: oracle } = useGetOracle({ nftContractAddress: data.address, chainId })
+	const { data: pools} = useGetAllPools({ chainId, collectionAddress: data.address })
 	const chainSymbol = chainConfig(chainId)?.nativeCurrency?.symbol
 	const floorPrice = Number(oracle?.price) / 1e18
 	return (
@@ -48,7 +50,7 @@ export function BorrowCollectionItemList({ data, chainName, chainId }: IBorrowCo
 			</div>
 
 			<div className="flex flex-col justify-center">
-				<h1>5</h1>
+				<h1>{pools?.length}</h1>
 				<p className="text-sm text-[#D4D4D8]">Loans</p>
 			</div>
 

--- a/components/Collection/index.tsx
+++ b/components/Collection/index.tsx
@@ -2,19 +2,17 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { chainConfig } from '~/lib/constants';
 import { useGetAllPools } from '~/queries/useGetAllPools';
-import { useGetOracle } from '~/queries/useGetOracle';
 
 interface IBorrowCollectionItemProps {
-	data: { name: string; address: string; imgUrl: string }
+	data: { name: string; address: string; imgUrl: string, oraclePrice?: string }
 	chainName: string
 	chainId?: number
 }
 
 export function BorrowCollectionItemList({ data, chainName, chainId }: IBorrowCollectionItemProps) {
-	const { data: oracle } = useGetOracle({ nftContractAddress: data.address, chainId })
 	const { data: pools} = useGetAllPools({ chainId, collectionAddress: data.address })
 	const chainSymbol = chainConfig(chainId)?.nativeCurrency?.symbol
-	const floorPrice = Number(oracle?.price) / 1e18
+	const floorPrice = Number(data.oraclePrice) / 1e18
 	const poolsWithLiquidity = pools?.filter(pool => Number(pool.totalDeposited) / 1e18 > 0.01)
 	const poolsTotalAvailableBalance = poolsWithLiquidity && poolsWithLiquidity?.map(pool => Number(pool.poolBalance) / 1e18).reduce((a, b) => a + b, 0)
 	const poolsMaxApr = poolsWithLiquidity && Math.max(...poolsWithLiquidity?.map(pool => Number(pool.currentAnnualInterest) / 1e16))
@@ -43,7 +41,7 @@ export function BorrowCollectionItemList({ data, chainName, chainId }: IBorrowCo
 			</div>
 
 			<div className="flex flex-col justify-center">
-				<h1>{oracle?.price ? `${floorPrice.toFixed(2)} ${chainSymbol}` : ''}</h1>
+				<h1>{data.oraclePrice ? `${floorPrice.toFixed(2)} ${chainSymbol}` : ''}</h1>
 				<p className="text-sm text-[#D4D4D8]">Floor</p>
 			</div>
 

--- a/components/Collection/index.tsx
+++ b/components/Collection/index.tsx
@@ -6,6 +6,58 @@ interface IBorrowCollectionItemProps {
 	chainName: string
 }
 
+export function BorrowCollectionItemList({ data, chainName }: IBorrowCollectionItemProps) {
+	return (
+		<li className="grid grid-cols-3 md:grid-cols-5 gap-4 min-h-[80px] min-w-[300px] bg-[#191919] p-4 shadow backdrop-blur justify-between">
+			<div className="flex gap-4">
+				<div className="flex flex-col justify-center">
+					<div className="relative min-h-[50px] min-w-[50px] w-full aspect-square">
+						{data.imgUrl === '' ? (
+							<div className="aspect-square rounded-xl bg-[#22242A]"></div>
+						) : (
+							<Image src={data.imgUrl} fill alt={data.name} className="aspect-square rounded-xl"  priority />
+						)}						
+					</div>
+				</div>
+
+				<div className="hidden md:block">
+					<h1 className="font-semibold">{data.name}</h1>
+					<p className="text-sm text-[#D4D4D8]">Collection</p>
+				</div>
+			</div>
+
+			<div className="block md:hidden">
+				<h1 className="font-semibold">{data.name}</h1>
+				<p className="text-sm text-[#D4D4D8]">Collection</p>
+			</div>
+
+			<div className="flex flex-col justify-center">
+				<h1>10.00 ETH</h1>
+				<p className="text-sm text-[#D4D4D8]">Floor</p>
+			</div>
+
+			<div className="flex flex-col justify-center">
+				<h1>123.00 ETH</h1>
+				<p className="text-sm text-[#D4D4D8]">Available</p>
+			</div>
+
+			<div className="flex flex-col justify-center">
+				<h1>5</h1>
+				<p className="text-sm text-[#D4D4D8]">Loans</p>
+			</div>
+
+			<div className="flex flex-col justify-center">
+				<Link
+					href={`/collections/${chainName}/${data.address}`}
+					className="rounded-xl bg-[#243b55] p-2 text-center text-sm min-w-[100px] max-w-[120px]"
+				>
+					View Pools
+				</Link>
+			</div>
+		</li>
+	)
+}
+
 export function BorrowCollectionItem({ data, chainName }: IBorrowCollectionItemProps) {
 	return (
 		<li className="flex min-h-[300px] min-w-[240px] flex-col gap-4 rounded-xl bg-[#191919] p-4 shadow backdrop-blur">

--- a/components/Collection/index.tsx
+++ b/components/Collection/index.tsx
@@ -15,6 +15,8 @@ export function BorrowCollectionItemList({ data, chainName, chainId }: IBorrowCo
 	const { data: pools} = useGetAllPools({ chainId, collectionAddress: data.address })
 	const chainSymbol = chainConfig(chainId)?.nativeCurrency?.symbol
 	const floorPrice = Number(oracle?.price) / 1e18
+	const poolsWithLiquidity = pools?.filter(pool => Number(pool.totalDeposited) > 0)
+	const poolsTotalAvailableBalance = poolsWithLiquidity && poolsWithLiquidity?.map(pool => Number(pool.poolBalance) / 1e18).reduce((a, b) => a + b, 0)
 	return (
 		<li className="grid grid-cols-3 md:grid-cols-5 gap-4 min-h-[80px] min-w-[300px] bg-[#191919] p-4 shadow backdrop-blur justify-between">
 			<div className="flex gap-4">
@@ -45,7 +47,7 @@ export function BorrowCollectionItemList({ data, chainName, chainId }: IBorrowCo
 			</div>
 
 			<div className="flex flex-col justify-center">
-				<h1>123.00 ETH</h1>
+				<h1>{poolsTotalAvailableBalance && `${poolsTotalAvailableBalance.toFixed(2)} ${chainSymbol}`}</h1>
 				<p className="text-sm text-[#D4D4D8]">Available</p>
 			</div>
 

--- a/components/Collection/index.tsx
+++ b/components/Collection/index.tsx
@@ -1,12 +1,18 @@
 import Image from 'next/image'
 import Link from 'next/link'
+import { chainConfig } from '~/lib/constants';
+import { useGetOracle } from '~/queries/useGetOracle';
 
 interface IBorrowCollectionItemProps {
 	data: { name: string; address: string; imgUrl: string }
 	chainName: string
+	chainId?: number
 }
 
-export function BorrowCollectionItemList({ data, chainName }: IBorrowCollectionItemProps) {
+export function BorrowCollectionItemList({ data, chainName, chainId }: IBorrowCollectionItemProps) {
+	const { data: oracle } = useGetOracle({ nftContractAddress: data.address, chainId })
+	const chainSymbol = chainConfig(chainId)?.nativeCurrency?.symbol
+	const floorPrice = Number(oracle?.price) / 1e18
 	return (
 		<li className="grid grid-cols-3 md:grid-cols-5 gap-4 min-h-[80px] min-w-[300px] bg-[#191919] p-4 shadow backdrop-blur justify-between">
 			<div className="flex gap-4">
@@ -32,7 +38,7 @@ export function BorrowCollectionItemList({ data, chainName }: IBorrowCollectionI
 			</div>
 
 			<div className="flex flex-col justify-center">
-				<h1>10.00 ETH</h1>
+				<h1>{oracle?.price ? `${floorPrice.toFixed(2)} ${chainSymbol}` : ''}</h1>
 				<p className="text-sm text-[#D4D4D8]">Floor</p>
 			</div>
 

--- a/containers/CollectionsContainer.tsx
+++ b/containers/CollectionsContainer.tsx
@@ -1,14 +1,20 @@
 import Head from 'next/head'
-import { BorrowCollectionItem } from '~/components/Collection'
+import { useState } from 'react'
+import { BorrowCollectionItemCard, BorrowCollectionItemList } from '~/components/Collection'
 import Layout from '~/components/Layout'
 import { useGetAllCollections } from '~/queries/useGetAllCollections'
 
+enum ViewType {
+	Card,
+	List,
+}
 interface ICollectionContainerProps {
 	chainId: number
 	chainName: string
 }
 
 const CollectionsContainer = ({ chainId, chainName }: ICollectionContainerProps) => {
+	const [viewType, setViewType] = useState<ViewType>(ViewType.List)
 	const { data: collections } = useGetAllCollections({ chainId, skipOracle: true })
 	return (
 		<>
@@ -22,11 +28,19 @@ const CollectionsContainer = ({ chainId, chainName }: ICollectionContainerProps)
 				) : collections?.length === 0 ? (
 					<p className="fallback-text">There are no collections on {chainName || 'this'} network.</p>
 				) : (
-					<ul className="mx-0 mt-8 mb-auto grid grid-cols-[repeat(auto-fit,minmax(240px,260px))] place-content-around gap-8 sm:my-9 2xl:place-content-between">
-						{collections?.map((item) => (
-							<BorrowCollectionItem key={item.address} data={item} chainName={chainName} />
-						))}
+					viewType === ViewType.Card ? (
+						<ul className="mx-0 mt-8 mb-auto grid grid-cols-[repeat(auto-fit,minmax(240px,260px))] place-content-around gap-8 sm:my-9 2xl:place-content-between">
+							{collections?.map((item) => (
+								<BorrowCollectionItemCard key={item.address} data={item} chainName={chainName} />
+							))}
+						</ul>
+					) : (
+						<ul className="grid grid-rows-1">
+							{collections?.map((item) => (
+								<BorrowCollectionItemList key={item.address} data={item} chainName={chainName} />
+							))}
 					</ul>
+					)
 				)}
 			</Layout>
 		</>

--- a/containers/CollectionsContainer.tsx
+++ b/containers/CollectionsContainer.tsx
@@ -37,7 +37,7 @@ const CollectionsContainer = ({ chainId, chainName }: ICollectionContainerProps)
 					) : (
 						<ul className="grid grid-rows-1">
 							{collections?.map((item) => (
-								<BorrowCollectionItemList key={item.address} data={item} chainName={chainName} />
+								<BorrowCollectionItemList key={item.address} data={item} chainId={chainId} chainName={chainName} />
 							))}
 					</ul>
 					)

--- a/containers/CollectionsContainer.tsx
+++ b/containers/CollectionsContainer.tsx
@@ -3,19 +3,61 @@ import { useState } from 'react'
 import { BorrowCollectionItemCard, BorrowCollectionItemList } from '~/components/Collection'
 import Layout from '~/components/Layout'
 import { useGetAllCollections } from '~/queries/useGetAllCollections'
+import { ICollection } from '~/types'
 
 enum ViewType {
 	Card,
 	List,
 }
+
 interface ICollectionContainerProps {
 	chainId: number
 	chainName: string
 }
 
+const renderCollectionItem = ({ chainId, chainName }: ICollectionContainerProps, collections: ICollection[] | undefined, viewType: ViewType ) => (
+	viewType === ViewType.Card ? (
+		<ul className="mx-0 mt-8 mb-auto grid grid-cols-[repeat(auto-fit,minmax(240px,260px))] place-content-around gap-8 sm:my-9 2xl:place-content-between">
+			{collections?.map((item) => (
+				<BorrowCollectionItemCard key={item.address} data={item} chainName={chainName} />
+			))}
+		</ul>
+	) : (
+		<ul className="grid grid-rows-1">
+			{collections?.map((item) => (
+				<BorrowCollectionItemList key={item.address} data={item} chainId={chainId} chainName={chainName} />
+			))}
+		</ul>
+	)
+)
+
+const ViewTypeSwitch = ({ viewType, onClick } : { viewType: ViewType, onClick: () => void }) => {
+	return (
+		<div className="flex items-center justify-end">
+			<div className="inline-flex pb-2" role="group" onClick={onClick}>
+				<button
+					type="button"
+					className={`rounded-l px-2 py-1 border-2 border-white font-medium text-xs ${viewType === ViewType.Card && "bg-white text-black"}`}
+				>
+					Grid
+				</button>
+				<button 
+					type="button"
+					className={`rounded-r px-2 py-1 border-2 border-white font-medium text-xs ${viewType === ViewType.List && "bg-white text-black"}`}
+				>
+					List
+				</button>
+			</div>
+		</div>
+	)
+}
+
 const CollectionsContainer = ({ chainId, chainName }: ICollectionContainerProps) => {
-	const [viewType, setViewType] = useState<ViewType>(ViewType.List)
+	const [viewType, setViewType] = useState<ViewType>(ViewType.Card)
 	const { data: collections } = useGetAllCollections({ chainId, skipOracle: true })
+	const toggleViewType = () => {
+		viewType === ViewType.Card ? setViewType(ViewType.List) : setViewType(ViewType.Card)
+	}
 	return (
 		<>
 			<Head>
@@ -28,19 +70,10 @@ const CollectionsContainer = ({ chainId, chainName }: ICollectionContainerProps)
 				) : collections?.length === 0 ? (
 					<p className="fallback-text">There are no collections on {chainName || 'this'} network.</p>
 				) : (
-					viewType === ViewType.Card ? (
-						<ul className="mx-0 mt-8 mb-auto grid grid-cols-[repeat(auto-fit,minmax(240px,260px))] place-content-around gap-8 sm:my-9 2xl:place-content-between">
-							{collections?.map((item) => (
-								<BorrowCollectionItemCard key={item.address} data={item} chainName={chainName} />
-							))}
-						</ul>
-					) : (
-						<ul className="grid grid-rows-1">
-							{collections?.map((item) => (
-								<BorrowCollectionItemList key={item.address} data={item} chainId={chainId} chainName={chainName} />
-							))}
-					</ul>
-					)
+					<>
+						<ViewTypeSwitch viewType={viewType} onClick={toggleViewType} />
+						{renderCollectionItem({chainName, chainId}, collections, viewType)}
+					</>
 				)}
 			</Layout>
 		</>

--- a/containers/CollectionsContainer.tsx
+++ b/containers/CollectionsContainer.tsx
@@ -8,10 +8,13 @@ import { ICollection } from '~/types'
 interface ICollectionContainerProps {
 	chainId: number
 	chainName: string
+}
+
+interface ICollections extends ICollectionContainerProps {
 	data: ICollection[] | undefined
 }
 
-const Collections = ({ chainId, chainName, data }: ICollectionContainerProps) => {
+const Collections = ({ chainId, chainName, data }: ICollections) => {
 	const router = useRouter()
 
 	const { view } = router.query

--- a/containers/CollectionsContainer.tsx
+++ b/containers/CollectionsContainer.tsx
@@ -54,7 +54,7 @@ const ViewTypeSwitch = ({ viewType, onClick } : { viewType: ViewType, onClick: (
 
 const CollectionsContainer = ({ chainId, chainName }: ICollectionContainerProps) => {
 	const [viewType, setViewType] = useState<ViewType>(ViewType.Card)
-	const { data: collections } = useGetAllCollections({ chainId, skipOracle: true })
+	const { data: collections } = useGetAllCollections({ chainId, skipOracle: false })
 	const toggleViewType = () => {
 		viewType === ViewType.Card ? setViewType(ViewType.List) : setViewType(ViewType.Card)
 	}

--- a/pages/collections/[chainName]/index.tsx
+++ b/pages/collections/[chainName]/index.tsx
@@ -39,7 +39,7 @@ export async function getStaticProps({ params: { chainName } }: { params: { chai
 
 	const queryClient = new QueryClient()
 
-	await queryClient.prefetchQuery(['allCollections', 1, true], () => getAllCollections({ chainId: 1 }))
+	await queryClient.prefetchQuery(['allCollections', 1, false], () => getAllCollections({ chainId: 1 }))
 
 	return {
 		props: { dehydratedState: dehydrate(queryClient), chainId: chainDetails.id, chainName: chainDetails.name },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,7 @@ import { getAllCollections } from '~/queries/useGetAllCollections'
 export async function getStaticProps() {
 	const queryClient = new QueryClient()
 
-	await queryClient.prefetchQuery(['allCollections', 1, true], () => getAllCollections({ chainId: 1 }))
+	await queryClient.prefetchQuery(['allCollections', 1, false], () => getAllCollections({ chainId: 1 }))
 
 	return {
 		props: { dehydratedState: dehydrate(queryClient) },

--- a/queries/useGetAllCollections.tsx
+++ b/queries/useGetAllCollections.tsx
@@ -6,9 +6,9 @@ import verifiedCollections from '~/lib/collections'
 import type { ICollection } from '~/types'
 
 export async function getAllCollections({ chainId }: { chainId?: number | null }) {
-	const pools = await getAllpools({ chainId, skipOracle: true })
+	const pools = await getAllpools({ chainId, skipOracle: false })
 
-	const collections: Array<{ address: string; name: string; totalDeposited: string }> = []
+	const collections: Array<{ address: string; name: string; totalDeposited: string, oraclePrice: string }> = []
 
 	pools.forEach((pool) => {
 		const index = collections.findIndex((col) => col.address.toLowerCase() === pool.nftContract.toLowerCase())
@@ -22,7 +22,8 @@ export async function getAllCollections({ chainId }: { chainId?: number | null }
 			collections.push({
 				address: getAddress(pool.nftContract),
 				name: pool.collectionName,
-				totalDeposited: pool.totalDeposited
+				totalDeposited: pool.totalDeposited,
+				oraclePrice: pool.oraclePrice,
 			})
 		}
 	})
@@ -31,7 +32,7 @@ export async function getAllCollections({ chainId }: { chainId?: number | null }
 
 	const notVerified: Array<ICollection> = []
 
-	Array.from(collections).forEach(({ address, name, totalDeposited }) => {
+	Array.from(collections).forEach(({ address, name, totalDeposited, oraclePrice }) => {
 		const verifiedCollectionIndex = verifiedCollections[chainId || 1].findIndex(
 			(x) => x.address.toLowerCase() == address.toLowerCase()
 		)
@@ -42,10 +43,18 @@ export async function getAllCollections({ chainId }: { chainId?: number | null }
 				name,
 				imgUrl: verifiedCollections[chainId || 1][verifiedCollectionIndex].imgUrl,
 				sortIndex: verifiedCollectionIndex + 1,
-				totalDeposited
+				totalDeposited,
+				oraclePrice
 			})
 		} else {
-			notVerified.push({ address, name, totalDeposited, imgUrl: '', sortIndex: -1 })
+			notVerified.push({
+				address,
+				name,
+				totalDeposited,
+				imgUrl: '',
+				sortIndex: -1,
+				oraclePrice
+			})
 		}
 	})
 

--- a/queries/useGetAllPools.tsx
+++ b/queries/useGetAllPools.tsx
@@ -76,7 +76,8 @@ async function getPoolAddlInfo({
 			pricePerNft: priceAndCurrentBorrowables.pricePerNft,
 			maxNftsToBorrow: priceAndCurrentBorrowables.maxNftsToBorrow,
 			currentAnnualInterest,
-			oracle
+			oracle,
+			oraclePrice: quote?.price,
 		}
 	} catch (error: any) {
 		throw new Error(error.message || (error?.reason ?? "Couldn't get total amount deposited in pool."))
@@ -263,6 +264,7 @@ export async function getAllpools({ chainId, collectionAddress, ownerAddress, sk
 				pricePerNft: poolAddlInfo?.[index]?.pricePerNft ?? '0',
 				maxNftsToBorrow: poolAddlInfo?.[index]?.maxNftsToBorrow ?? '0',
 				oracle: poolAddlInfo?.[index]?.oracle ?? '',
+				oraclePrice: poolAddlInfo?.[index]?.oraclePrice ?? '',
 				adminPoolInfo: adminPoolInfo?.[index] ?? {}
 			}))
 			.sort((a, b) => Number(b.maxNftsToBorrow) - Number(a.maxNftsToBorrow))

--- a/types.ts
+++ b/types.ts
@@ -143,4 +143,5 @@ export interface ICollection {
 	totalDeposited: string
 	imgUrl: string
 	sortIndex: number
+	oraclePrice?: string
 }


### PR DESCRIPTION
The current card-view makes it hard to have a glance at every collection available, hence a list-view might be useful for such cases. I've also included a toggle button to switch between the card-view and list-view (default is card-view)

The list view shows a few more information:
- Floor price
- highest possible APR
- loanable ETH amount
- total number of loans 

Above shown information (and accompanying text) is debatable. Open for opinons.

Web Preview:
<img width="1419" alt="image" src="https://user-images.githubusercontent.com/75980156/205441216-339816bb-4360-44c0-9bff-2076c2195b30.png">

Mobile Preview (cut-off at md):
<img width="483" alt="image" src="https://user-images.githubusercontent.com/75980156/205441250-69207e98-dd6b-4c8d-bdff-f6119fa1e20d.png">
